### PR TITLE
Fix CARMAWebUi - Update Fatal and Shutdown Response on the UI

### DIFF
--- a/website/scripts/rosbridge.js
+++ b/website/scripts/rosbridge.js
@@ -367,12 +367,17 @@ function checkSystemAlerts() {
                 HideCloseBtn:	false});
                 break;
 
-            case 3: //FATAL
-                //Show modal popup for Fatal alerts.
-                messageTypeFullDescription = 'System received a FATAL message. Please wait for system to shut down. <br/><br/>' + message.description;
-                messageTypeFullDescription += '<br/><br/>PLEASE TAKE MANUAL CONTROL OF THE VEHICLE.';
-                listenerSystemAlert.unsubscribe();
-                showModal(true, messageTypeFullDescription, false);
+            case 3: //FATAL - equivalent to CRITICAL "error". Don't use the word FATAL to describe to users.
+                addToLogView ('CRITICAL: ' + message.description);
+
+                MsgPop.open({
+                Type:			"error",
+                Content:		message.description,
+                AutoClose:		true,
+                CloseTimer:		30000,
+                ClickAnyClose:	true,
+                ShowIcon:		true,
+                HideCloseBtn:	false});
                 break;
             case 4://NOT_READY
                 isSystemAlert.ready = false;
@@ -384,6 +389,13 @@ function checkSystemAlerts() {
                 break;
             case 6: //SHUTDOWN
                 isSystemAlert.ready = false;
+
+                //Show modal popup for Fatal alerts.
+                messageTypeFullDescription = 'System is shutting down. <br/><br/>' + message.description;
+                messageTypeFullDescription += '<br/><br/>PLEASE TAKE MANUAL CONTROL OF THE VEHICLE.';
+                listenerSystemAlert.unsubscribe();
+                showModal(true, messageTypeFullDescription, false);
+
                 listenerSystemAlert.unsubscribe();
                 break;
             default:
@@ -982,8 +994,8 @@ function checkGuidanceState() {
                 setCAVButtonState('INACTIVE');
                 break;
             case 0: //SHUTDOWN
-                //Show modal popup for Shutdown alerts from Guidance, which is equivalent to Fatal since it cannot restart with this state.
-                messageTypeFullDescription = 'System received a Guidance SHUTDOWN. <br/><br/>' + message.description;
+                //Show modal popup for Shutdown alerts Health Monitor. Guidance and other nodes may issue FATAL however, SHUTDOWN will only occur when FATAL is received from the nodes are required.
+                messageTypeFullDescription = 'System received a SYSTEM SHUTDOWN. <br/><br/>' + message.description;
                 messageTypeFullDescription += '<br/><br/>PLEASE TAKE MANUAL CONTROL OF THE VEHICLE.';
 
                 if(listenerSystemAlert != null && listenerSystemAlert != 'undefined')


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
Refer to https://github.com/usdot-fhwa-stol/carma-platform/issues/918

## Description
Refer to https://github.com/usdot-fhwa-stol/carma-platform/issues/918

The change on UI is to ensure it does not shutdown the UI when FATAL is received. Instead:

When FATAL occurs, a new "critical error" shall be displayed.
When SHUTDOWN occurs, a popup will be shown that system has shut down message. 
The shutdown message should include the reason why the shut down occurred from the required node, instead of just saying "Node shutting down."

REQUIREMENT: It must run against the updates made to the health monitor under https://usdot-carma.atlassian.net/browse/CAR-2035

<!--- Describe your changes in detail -->

## Related Issue
https://github.com/usdot-fhwa-stol/carma-platform/issues/918
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Refer to https://github.com/usdot-fhwa-stol/carma-platform/issues/918

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local development and send screenshots to @msmcconnell  and Isaiah

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.