### PR TITLE
Fix topic mismatch on basic travel UI

### DIFF
--- a/website/scripts/app/global_variables.js
+++ b/website/scripts/app/global_variables.js
@@ -55,6 +55,9 @@ const T_LOCALIZATION_STATUS = '/localization/localization_status';
 const T_STEERING_WHEEL="/hardware_interface/steering_wheel";
 const T_SPEED_PEDALS ="/hardware_interface/speed_pedals";
 const T_GPS_NODELET_WRAPPER='/hardware_interface/novatel_gps_nodelet_wrapper';
+const T_STEERING_WHEEL_FEEDBACK = "/hardware_interface/steering_feedback";
+const T_THROTTLE_FEEDBACK = "/hardware_interface/throttle_feedback";
+const T_BRAKE_FEEDBACK = "/hardware_interface/brake_feedback";
 
 //ROS Services names
 const S_GUIDANCE_AVAILABLE_ROUTES = '/guidance/get_available_routes';
@@ -99,6 +102,9 @@ const M_PLATOON_INFO = 'cav_msgs/PlatooningInfo';
 const M_LOCALIZATION_REPORT = 'cav_msgs/LocalizationStatusReport';
 const M_STEERING_WHEEL="automotive_platform_msgs/SteerWheel";
 const M_SPEED_PEDALS="automotive_platform_msgs/SpeedPedals";
+const M_THROTTLE_FEEDBACK="automotive_platform_msgs/ThrottleFeedback";
+const M_STEERING_FEEDBACK="automotive_platform_msgs/SteeringFeedback";
+const M_BRAKE_FEEDBACK="automotive_platform_msgs/BrakeFeedback";
 
 //ROS param names
 const P_REQUIRED_PLUGINS = '/guidance/health_monitor/required_plugins';

--- a/website/scripts/app/global_variables.js
+++ b/website/scripts/app/global_variables.js
@@ -21,6 +21,7 @@ const WIFI = 'wifi';
 const BLUETOOTH = 'bluetooth';
 const CELLULAR = 'cellular';
 const NONE = 'none';
+const DEG2RAD = 0.0174533;
 
 //ROS Topci names
 const T_GUIDANCE_STATE = '/guidance/state';

--- a/website/scripts/app/subscribeROSServicesOnLoad.js
+++ b/website/scripts/app/subscribeROSServicesOnLoad.js
@@ -87,9 +87,10 @@ $(document).ready(function(){
              * SECTION: Display Area
              * **/
             subscribeToLocalizationEKFTwist(); //Current Vehicle Speed
-            subscribeToVehicleCMD(); //Vechile Command;  applied speed; accelerator  
-            subscribeToSteeringWheel(); //Steering angle
-            subscribeToSpeedPedals(); //brake;
+            subscribeToVehicleCMD(); //Vechile Command;  applied speed; 
+            sunscribeToSteeringFeedback(); //Steering angle
+            sunscribeToBrakeFeedback(); //brake;
+            sunscribeToThrottleFeedback(); //accelerator  
             subscribeToGuidanceRouteState(); //Route - Speed Limit        
             TrafficSignalInfoList(); //Traffic Signal 
             subscribeLightBarStatus(); //light bar

--- a/website/scripts/ros/ros_host_vehicle_cmd.js
+++ b/website/scripts/ros/ros_host_vehicle_cmd.js
@@ -185,11 +185,15 @@ function sunscribeToSteeringFeedback()
             vehicle_steer_lim_deg = session_hostVehicle.steeringLimit;
             vehicle_steering_gear_ratio =session_hostVehicle.steeringRatio;
             current_steering_angle = message.steering_wheel_angle;
+            //current_steering_angle is unit of rad and convert to unit degree before assign to rotateDegree
+            //let rotateDegree = Math.ceil(current_steering_angle * 180/(Math.PI));
 
-            let rotateDegree = Math.ceil(current_steering_angle * 180/(Math.PI));
-            let rotateDegreeModule = - (rotateDegree % (vehicle_steer_lim_deg * vehicle_steering_gear_ratio));; 
+            //steer_percentage is the percentage text displayed at the center of the image
             let steer_percentage = Math.abs(((current_steering_angle/(vehicle_steering_gear_ratio*vehicle_steer_lim_deg * DEG2RAD))* 100).toFixed(0));
-            
+
+            //rorate Degree Module is the degree the image rotate. 
+           // let rotateDegreeModule = - (rotateDegree % (vehicle_steer_lim_deg * vehicle_steering_gear_ratio)); 
+           let rotateDegreeModule = steer_percentage * 360
             //Accelerator Progress
             updateSteeringWheel(steer_percentage+ "%",rotateDegreeModule);
         }

--- a/website/scripts/ros/ros_host_vehicle_cmd.js
+++ b/website/scripts/ros/ros_host_vehicle_cmd.js
@@ -145,10 +145,10 @@ function subscribeToSteeringWheelOLD()
         if(message.angle != null)
         {
             //steering  percentage
-            let vehicle_steer_lim_deg_rad = session_hostVehicle.steeringLimit * 180/pi;
-            let maximum_steering_wheel_angle = session_hostVehicle.steeringRatio * vehicle_steer_lim_deg_rad;
-            let steer_percentage = (message.angle / maximum_steering_wheel_angle) * 100;
-
+            let vehicle_steer_lim_deg = session_hostVehicle.steeringLimit;
+            let vehicle_steering_gear_ratio = session_hostVehicle.steeringRatio;
+            let current_steering_angle = message.angle;
+            let steer_percentage = (current_steering_angle/(vehicle_steering_gear_ratio*vehicle_steer_lim_deg * DEG2RAD))* 100;
             //steering degree
             let rotateDegree = message.angle * 180/(Math.PI);
             let rotateDegreeModule = rotateDegree % 360; 

--- a/website/scripts/ros/ros_host_vehicle_cmd.js
+++ b/website/scripts/ros/ros_host_vehicle_cmd.js
@@ -21,40 +21,7 @@ function subscribeToVehicleCMD()
         IsROSBridgeConnected();
         
         if(message!=null && message.ctrl_cmd !=null)
-        {
-            // //Steering wheel
-            // if(message.ctrl_cmd.steering_angle != null)
-            // {
-            //     let rad = message.ctrl_cmd.steering_angle;
-            //     let rotateDegree = rad % 360; //-35 to +35
-            //     // console.log('rotateDegree'+rotateDegree);
-            //     let degreePercent = Math.floor(((rotateDegree/360) * 100));
-            //     updateSteeringWheel(degreePercent +'%',rotateDegree);
-            // }            
-            //Brake
-            // if(message.brake_cmd.brake != null && g_brakeCircle != null)
-            // {
-            //     let max, brakeLimit = '';
-            //     //set brake  limit to the host vehicle deceleration(brake) limit if exist in session, otherwise default to 6
-            //     if(message.brake_cmd.brake>0)
-            //         brakeLimit = session_hostVehicle.brakeLimit;
-                
-            //         max =  brakeLimit != null && brakeLimit.length > 0? brakeLimit: 6;
-            //     let value = message.brake_cmd.brake;
-            //     updateBrake(g_brakeCircle,max,value);
-            // }
-            //Accelerator
-            if(message.ctrl_cmd.linear_acceleration != null  && g_acceleratorCircle != null)
-            {
-                let max, accelerationLimit = '';
-                //set acceleration limit to the host vehicle acceleration limit if exist in session, otherwise default to 3
-                if(message.ctrl_cmd.linear_acceleration > 0)
-                   accelerationLimit = session_hostVehicle.accelerationLimit;
-
-                max =  accelerationLimit != null && accelerationLimit.length > 0? accelerationLimit : 3;
-                let value = message.ctrl_cmd.linear_acceleration;
-                updateAccerator(g_acceleratorCircle,max,value);
-            }
+        {       
             //Applied/Command Speed
             if(message.ctrl_cmd.linear_velocity != null)
             {
@@ -65,11 +32,78 @@ function subscribeToVehicleCMD()
         }
     });
 }
+/**Accelerator Feedback position from ssc_interface package
+ * Topic: /hardware_interface/throttle_feedback 
+ * Message: automotive_platform_msgs/ThrottleFeedback
+            std_msgs/Header header
+                uint32 seq
+                time stamp
+                string frame_id
+            float32 throttle_pedal
+ */
+function sunscribeToThrottleFeedback()
+{
+    var listener = new ROSLIB.Topic({
+        ros:g_ros,
+        name: T_THROTTLE_FEEDBACK,
+        messageType: M_THROTTLE_FEEDBACK
+    });
+    listener.subscribe(function(message){
+        //Check ROSBridge connection before subscribe a topic
+        IsROSBridgeConnected();
+        if(message!=null && message.throttle_pedal!=null)
+        {
+            let value = message.throttle_pedal;
+            let max, accelerationLimit = '';
+            accelerationLimit = session_hostVehicle.accelerationLimit;
+            max =  accelerationLimit != null && accelerationLimit.length > 0? accelerationLimit : 3;
+            //Accelerator Progress
+            if(g_acceleratorCircle != null)
+            {
+                updateAccerator(g_acceleratorCircle,max,value);
+            }
+        }
+    });
+}
+
+/**brake_feedback from ssc_interface package
+ * Topic: /hardware_interface/brake_feedback 
+ * Message: automotive_platform_msgs/BrakeFeedback
+            std_msgs/Header header
+                uint32 seq
+                time stamp
+                string frame_id
+            float32 brake_pedal
+ */
+function sunscribeToBrakeFeedback()
+{
+    var listener = new ROSLIB.Topic({
+        ros:g_ros,
+        name: T_BRAKE_FEEDBACK,
+        messageType: M_BRAKE_FEEDBACK
+    });
+    listener.subscribe(function(message){
+        //Check ROSBridge connection before subscribe a topic
+        IsROSBridgeConnected();
+        if(message!=null && message.brake_pedal!=null)
+        {
+            let value = message.brake_pedal;
+            let max, brakeLimit = '';
+            brakeLimit = session_hostVehicle.brakeLimit;
+            max =  brakeLimit != null && brakeLimit.length > 0? brakeLimit : 6;
+            //Accelerator Progress
+            if(g_brakeCircle != null)
+            {
+                updateBrake(g_brakeCircle,max,value);
+            }
+        }
+    });
+}
 
 /**
  * /hardware_interface/speed_pedals
  */
-function subscribeToSpeedPedals()
+function subscribeToSpeedPedalsOLD()
 {
     var listener = new ROSLIB.Topic({
         ros: g_ros,
@@ -90,10 +124,12 @@ function subscribeToSpeedPedals()
         }
     });
 }
+
+
 /**
  * /hardware_interface/steering_wheel 
  */
-function subscribeToSteeringWheel()
+function subscribeToSteeringWheelOLD()
 {
     var listener = new ROSLIB.Topic({
         ros: g_ros,
@@ -125,5 +161,43 @@ function subscribeToSteeringWheel()
 
             updateSteeringWheel(steer_percentage+ "%",rotateDegreeModule);
         }  
+    });
+}
+
+
+/**steering_feedback from ssc_interface package
+ * Topic: /hardware_interface/steering_feedback 
+ * Message: automotive_platform_msgs/BrakeFeedback
+            std_msgs/Header header
+                uint32 seq
+                time stamp
+                string frame_id
+            float32 steering_wheel_angle
+ */
+function sunscribeToSteeringFeedback()
+{
+    var listener = new ROSLIB.Topic({
+        ros:g_ros,
+        name: T_STEERING_WHEEL_FEEDBACK,
+        messageType: M_STEERING_FEEDBACK
+    });
+    listener.subscribe(function(message){
+        //Check ROSBridge connection before subscribe a topic
+        IsROSBridgeConnected();
+
+        if(message!=null && message.steering_wheel_angle!=null)
+        {
+            let value, vehicle_steer_ratio,vehicle_steer_lim_deg = '';
+            vehicle_steer_lim_deg = session_hostVehicle.steeringLimit;
+            vehicle_steer_ratio =session_hostVehicle.steeringRatio;
+            value = message.steering_wheel_angle;
+
+            let rotateDegree = Math.ceil(value * 180/(Math.PI));
+            let rotateDegreeModule = - (rotateDegree % (vehicle_steer_lim_deg * vehicle_steer_ratio));; 
+            let steer_percentage = Math.abs(((rotateDegree / (vehicle_steer_lim_deg * vehicle_steer_ratio))*100).toFixed(0));
+
+            //Accelerator Progress
+            updateSteeringWheel(steer_percentage+ "%",rotateDegreeModule);
+        }
     });
 }

--- a/website/scripts/ros/ros_host_vehicle_cmd.js
+++ b/website/scripts/ros/ros_host_vehicle_cmd.js
@@ -54,13 +54,10 @@ function sunscribeToThrottleFeedback()
         if(message!=null && message.throttle_pedal!=null)
         {
             let value = message.throttle_pedal;
-            let max, accelerationLimit = '';
-            accelerationLimit = session_hostVehicle.accelerationLimit;
-            max =  accelerationLimit != null && accelerationLimit.length > 0? accelerationLimit : 3;
             //Accelerator Progress
             if(g_acceleratorCircle != null)
             {
-                updateAccerator(g_acceleratorCircle,max,value);
+                updateAccerator(g_acceleratorCircle,1,value);
             }
         }
     });
@@ -88,13 +85,10 @@ function sunscribeToBrakeFeedback()
         if(message!=null && message.brake_pedal!=null)
         {
             let value = message.brake_pedal;
-            let max, brakeLimit = '';
-            brakeLimit = session_hostVehicle.brakeLimit;
-            max =  brakeLimit != null && brakeLimit.length > 0? brakeLimit : 6;
             //Accelerator Progress
             if(g_brakeCircle != null)
             {
-                updateBrake(g_brakeCircle,max,value);
+                updateBrake(g_brakeCircle,1,value);
             }
         }
     });

--- a/website/scripts/ros/ros_host_vehicle_cmd.js
+++ b/website/scripts/ros/ros_host_vehicle_cmd.js
@@ -185,17 +185,20 @@ function sunscribeToSteeringFeedback()
             vehicle_steer_lim_deg = session_hostVehicle.steeringLimit;
             vehicle_steering_gear_ratio =session_hostVehicle.steeringRatio;
             current_steering_angle = message.steering_wheel_angle;
-            //current_steering_angle is unit of rad and convert to unit degree before assign to rotateDegree
-            let rotateDegree = Math.ceil(current_steering_angle * 180/(Math.PI));
+            let maximum_steering_wheel_angle_deg = vehicle_steering_gear_ratio * vehicle_steer_lim_deg;
 
-            //steer_percentage is the percentage text displayed at the center of the image
-            let steer_percentage = ((current_steering_angle/(vehicle_steering_gear_ratio*vehicle_steer_lim_deg * DEG2RAD))* 100).toFixed(0);
+            //current_steering_angle is unit of rad and convert to unit degree before assign to rotate_deg
+            let rotate_deg = Math.ceil(current_steering_angle * 180/(Math.PI));
 
-            //rorate Degree Module is the degree the image rotate. 
-            let rotateDegreeModule = - (rotateDegree % (vehicle_steer_lim_deg * vehicle_steering_gear_ratio)); 
-           //let rotateDegreeModule = steer_percentage * 360
+            //steer_percentage is the percentage text displayed at the center of the steering_wheel image
+            let steer_percentage = ((current_steering_angle/( maximum_steering_wheel_angle_deg * DEG2RAD ))* 100).toFixed(0);
+
+            //rorate degree Offset is the degree if steering_wheel image rotation. 
+            let offset_rotate_deg = - (rotate_deg % maximum_steering_wheel_angle_deg); 
+
+            //let offset_rotate_deg = steer_percentage * 360
             //Accelerator Progress
-            updateSteeringWheel(steer_percentage+ "%",rotateDegreeModule);
+            updateSteeringWheel(steer_percentage+ "%",offset_rotate_deg);
         }
     });
 }

--- a/website/scripts/ros/ros_host_vehicle_cmd.js
+++ b/website/scripts/ros/ros_host_vehicle_cmd.js
@@ -148,7 +148,7 @@ function subscribeToSteeringWheelOLD()
             let vehicle_steer_lim_deg = session_hostVehicle.steeringLimit;
             let vehicle_steering_gear_ratio = session_hostVehicle.steeringRatio;
             let current_steering_angle = message.angle;
-            let steer_percentage = (current_steering_angle/(vehicle_steering_gear_ratio*vehicle_steer_lim_deg * DEG2RAD))* 100;
+            let steer_percentage = Math.abs(((current_steering_angle/(vehicle_steering_gear_ratio*vehicle_steer_lim_deg * DEG2RAD))* 100).toFixed(0));
             //steering degree
             let rotateDegree = message.angle * 180/(Math.PI);
             let rotateDegreeModule = rotateDegree % 360; 
@@ -181,15 +181,15 @@ function sunscribeToSteeringFeedback()
 
         if(message!=null && message.steering_wheel_angle!=null)
         {
-            let value, vehicle_steer_ratio,vehicle_steer_lim_deg = '';
+            let current_steering_angle, vehicle_steering_gear_ratio,vehicle_steer_lim_deg = '';
             vehicle_steer_lim_deg = session_hostVehicle.steeringLimit;
-            vehicle_steer_ratio =session_hostVehicle.steeringRatio;
-            value = message.steering_wheel_angle;
+            vehicle_steering_gear_ratio =session_hostVehicle.steeringRatio;
+            current_steering_angle = message.steering_wheel_angle;
 
-            let rotateDegree = Math.ceil(value * 180/(Math.PI));
-            let rotateDegreeModule = - (rotateDegree % (vehicle_steer_lim_deg * vehicle_steer_ratio));; 
-            let steer_percentage = Math.abs(((rotateDegree / (vehicle_steer_lim_deg * vehicle_steer_ratio))*100).toFixed(0));
-
+            let rotateDegree = Math.ceil(current_steering_angle * 180/(Math.PI));
+            let rotateDegreeModule = - (rotateDegree % (vehicle_steer_lim_deg * vehicle_steering_gear_ratio));; 
+            let steer_percentage = Math.abs(((current_steering_angle/(vehicle_steering_gear_ratio*vehicle_steer_lim_deg * DEG2RAD))* 100).toFixed(0));
+            
             //Accelerator Progress
             updateSteeringWheel(steer_percentage+ "%",rotateDegreeModule);
         }

--- a/website/scripts/ros/ros_host_vehicle_cmd.js
+++ b/website/scripts/ros/ros_host_vehicle_cmd.js
@@ -191,7 +191,7 @@ function sunscribeToSteeringFeedback()
             let rotate_deg = Math.ceil(current_steering_angle * 180/(Math.PI));
 
             //steer_percentage is the percentage text displayed at the center of the steering_wheel image
-            let steer_percentage = ((current_steering_angle/( maximum_steering_wheel_angle_deg * DEG2RAD ))* 100).toFixed(0);
+            let steer_percentage = - ((current_steering_angle/( maximum_steering_wheel_angle_deg * DEG2RAD ))* 100).toFixed(0);
 
             //rorate degree Offset is the degree if steering_wheel image rotation. 
             let offset_rotate_deg = - (rotate_deg % maximum_steering_wheel_angle_deg); 

--- a/website/scripts/ros/ros_host_vehicle_cmd.js
+++ b/website/scripts/ros/ros_host_vehicle_cmd.js
@@ -186,14 +186,14 @@ function sunscribeToSteeringFeedback()
             vehicle_steering_gear_ratio =session_hostVehicle.steeringRatio;
             current_steering_angle = message.steering_wheel_angle;
             //current_steering_angle is unit of rad and convert to unit degree before assign to rotateDegree
-            //let rotateDegree = Math.ceil(current_steering_angle * 180/(Math.PI));
+            let rotateDegree = Math.ceil(current_steering_angle * 180/(Math.PI));
 
             //steer_percentage is the percentage text displayed at the center of the image
-            let steer_percentage = Math.abs(((current_steering_angle/(vehicle_steering_gear_ratio*vehicle_steer_lim_deg * DEG2RAD))* 100).toFixed(0));
+            let steer_percentage = ((current_steering_angle/(vehicle_steering_gear_ratio*vehicle_steer_lim_deg * DEG2RAD))* 100).toFixed(0);
 
             //rorate Degree Module is the degree the image rotate. 
-           // let rotateDegreeModule = - (rotateDegree % (vehicle_steer_lim_deg * vehicle_steering_gear_ratio)); 
-           let rotateDegreeModule = steer_percentage * 360
+            let rotateDegreeModule = - (rotateDegree % (vehicle_steer_lim_deg * vehicle_steering_gear_ratio)); 
+           //let rotateDegreeModule = steer_percentage * 360
             //Accelerator Progress
             updateSteeringWheel(steer_percentage+ "%",rotateDegreeModule);
         }


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Testing of integration/routing showed that the steering, brake, accelerator indicators on the basic travel UI were not reporting good or consistent values. It seems the data might not be coming from the correct topics. The best topics to use in this case are the following:

/hardware_interface/steering_feedback # Steering wheel
/hardware_interface/throttle_feedback # Accelerator position
/hardware_interface/brake_feedback # Brake position

UI should be updated as needed to resolve this.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Basic Travel Use Case
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
In vehicle integration testing
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
JS and logic
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.