### PR TITLE
Cannot restart same route after getting LEFT ROUTE event 

### DIFF
--- a/website/scripts/app/subscribeROSServicesOnLoad.js
+++ b/website/scripts/app/subscribeROSServicesOnLoad.js
@@ -73,8 +73,14 @@ $(document).ready(function(){
             ***/
             
             //SECTION: Route Area
-            //call abort active route to reinforce route transition to selection state
-            abortActiveRoute();
+            if(sessionStorage.getItem('selectedRouteName')===null ||
+                sessionStorage.getItem('selectedRouteId') ===null ||                
+                sessionStorage.getItem('isGuidanceActive') ===null)
+            {
+                console.log("Calling abort active route.");
+                //call abort active route to reinforce route transition to selection state
+                abortActiveRoute();
+            }
 
             //Get available routes
             subscribeToGuidanceAvailaleRoutes(); 


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Abort active route only when session is clear and before calling get list of available route in case the restart button request was not processed.
<!--- Describe your changes in detail -->

## Related Issue
usdot-fhwa-stol/carma-platform#1057
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
release-plas
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.