### PR TITLE
Assign 'choice' field to SetActiveRoute service request (re-commits change from PR #92)

### DIFF
--- a/website/scripts/ros/ros_route.js
+++ b/website/scripts/ros/ros_route.js
@@ -120,6 +120,7 @@ function setRoute(id,route_name)
 
     // Create a Service Request.
     var request = new ROSLIB.ServiceRequest({
+        choice: 0, // choice '0' indicates that a routeID is being provided for this setActiveRoute service request
         routeID: selectedRouteid
     });
 


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->

This PR re-commits the change from PR #92 that was reverted by PR #101. The initial description from PR #92 is included below:

CARMA Platform PR #1321 and carma-msgs PR # resulted in an updated description for cav_srvs/SetActiveRoute. Specifically, a 'choice' field was added to the request to indicate whether a SetActiveRoute request includes a RouteID (the name of a route file) or an array of destination points. Since carma-web-ui only deals with routes provided with a RouteID, the choice field is set to '0' (which indicates a RouteID is being provided).

Related PRs:

carma-platform: PR #1321
carma-msgs: PR #110

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Integration tested on Silver Lexus.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.