### PR TITLE
Fix usdot-fhwa-stol/carma-platform#1703

### DIFF
--- a/website/scripts/ros/ros_system_alert.js
+++ b/website/scripts/ros/ros_system_alert.js
@@ -20,105 +20,109 @@ function checkSystemAlerts() {
             messageType: M_SYSTEM_ALERT
         });
 
+        // Then we add a callback to be called every time a message is published on this topic.
+        systemAlertCallback = function (message) 
+        {
+            //Check ROSBridge connection before subscribe a topic
+            IsROSBridgeConnected();
+            var messageTypeFullDescription = 'NA';
+            console.log("system alert type" + message.type);
+            switch (message.type) 
+            {
+                case SYSTEM_ALERT_CAUTION:
+                    session_isSystemAlert.ready = false;
+                    messageTypeFullDescription = 'System received a CAUTION message. ' + message.description;
+                    MsgPop.open({
+                        Type:			"caution",
+                        Content:		message.description,
+                        AutoClose:		true,
+                        CloseTimer:		30000,
+                        ClickAnyClose:	true,
+                        ShowIcon:		true,
+                        HideCloseBtn:	false});
+                    break;
+
+                case SYSTEM_ALERT_WARNING:
+                    session_isSystemAlert.ready = false;
+                    messageTypeFullDescription = 'System received a WARNING message. ' + message.description;
+                    MsgPop.open({
+                        Type:			"warning",
+                        Content:		message.description,
+                        AutoClose:		true,
+                        CloseTimer:		30000,
+                        ClickAnyClose:	true,
+                        ShowIcon:		true,
+                        HideCloseBtn:	false});
+                    break;
+
+                case SYSTEM_ALERT_FATAL:
+                    session_isSystemAlert.ready = false;
+                    messageTypeFullDescription = 'System received a CRITICAL message. ' + message.description;
+                    MsgPop.open({
+                        Type:           "error",
+                        Content:        message.description,
+                        AutoClose:      true,
+                        ClickAnyClose:  true,
+                        ShowIcon:       true,
+                        HideCloseBtn:   false
+                    });
+                    break;
+
+                case SYSTEM_ALERT_NOT_READY:
+                    session_isSystemAlert.ready = false;
+                    messageTypeFullDescription = 'System not ready, please wait and try again. ' + message.description;
+                    break;
+
+                case SYSTEM_ALERT_DRIVERS_READY: 
+                    session_isSystemAlert.ready = true;
+                    messageTypeFullDescription = 'System ready. ' + message.description;
+                    $('#divCapabilitiesSystemAlert').html('');
+                    break;
+
+                case SYSTEM_ALERT_SHUTDOWN: 
+                    session_isSystemAlert.ready = false;
+                    listenerSystemAlert.unsubscribe();
+                    //Show modal popup for Fatal alerts.
+                    messageTypeFullDescription = 'PLEASE TAKE <strong>MANUAL</strong> CONTROL OF THE VEHICLE.';
+                    messageTypeFullDescription += '<br/><br/>System received a SHUTDOWN message. Please wait for system to shut down. <br/><br/>' + message.description;
+                    listenerSystemAlert.unsubscribe();
+                    //If this modal does not exist, create one 
+                    if( $('#systemAlertModal').length < 1 ) 
+                    { 
+                        $('#ModalsArea').append(createSystemAlertModal(
+                            '<span style="color:red"><i class="fas fa-exclamation-triangle"></i></span>&nbsp;&nbsp;SYSTEM ALERT', 
+                            messageTypeFullDescription,
+                            false,true
+                            ));              
+                    }
+                    $('#systemAlertModal').modal({backdrop: 'static', keyboard: false}); 
+                    playSound('audioAlert1', false);
+                    break;
+
+                default:
+                    session_isSystemAlert.ready = false;
+                    messageTypeFullDescription = 'System alert type is unknown. Assuming system it not yet ready.  ' + message.description;
+                    break;
+            }
+            let currentTime = new Date().toLocaleTimeString("en-US", {timeZone: "America/New_York"});
+            let eachElement = currentTime+'-'+messageTypeFullDescription + "&#13;&#10;";
+            let eachElementLeight = eachElement.length;
+            $('#logs-panel-text-system-alert').prepend( eachElement );        
+            let currnettext = $('#logs-panel-text-system-alert').html();
+            if ( (currnettext.length / eachElementLeight) > MAX_LOG_LINES) 
+            {
+                $('#logs-panel-text-system-alert').html( currnettext.substring(0, (currnettext.length - eachElementLeight)) );
+            }
+        };
+
     } 
     else // If it was defined, close the existing subscription so it can be reopened
     {
-        listenerSystemAlert.unsubscribe()
+        listenerSystemAlert.unsubscribe(systemAlertCallback)
     }
 
 
-    // Then we add a callback to be called every time a message is published on this topic.
-    listenerSystemAlert.subscribe(function (message) 
-    {
-         //Check ROSBridge connection before subscribe a topic
-         IsROSBridgeConnected();
-        var messageTypeFullDescription = 'NA';
-        console.log("system alert type" + message.type);
-        switch (message.type) 
-        {
-            case SYSTEM_ALERT_CAUTION:
-                session_isSystemAlert.ready = false;
-                messageTypeFullDescription = 'System received a CAUTION message. ' + message.description;
-                MsgPop.open({
-                    Type:			"caution",
-                    Content:		message.description,
-                    AutoClose:		true,
-                    CloseTimer:		30000,
-                    ClickAnyClose:	true,
-                    ShowIcon:		true,
-                    HideCloseBtn:	false});
-                break;
+    
 
-            case SYSTEM_ALERT_WARNING:
-                session_isSystemAlert.ready = false;
-                messageTypeFullDescription = 'System received a WARNING message. ' + message.description;
-                MsgPop.open({
-                    Type:			"warning",
-                    Content:		message.description,
-                    AutoClose:		true,
-                    CloseTimer:		30000,
-                    ClickAnyClose:	true,
-                    ShowIcon:		true,
-                    HideCloseBtn:	false});
-                break;
-
-            case SYSTEM_ALERT_FATAL:
-                session_isSystemAlert.ready = false;
-                messageTypeFullDescription = 'System received a CRITICAL message. ' + message.description;
-                MsgPop.open({
-                    Type:           "error",
-                    Content:        message.description,
-                    AutoClose:      true,
-                    ClickAnyClose:  true,
-                    ShowIcon:       true,
-                    HideCloseBtn:   false
-                });
-                break;
-
-            case SYSTEM_ALERT_NOT_READY:
-                session_isSystemAlert.ready = false;
-                messageTypeFullDescription = 'System not ready, please wait and try again. ' + message.description;
-                break;
-
-            case SYSTEM_ALERT_DRIVERS_READY: 
-                session_isSystemAlert.ready = true;
-                messageTypeFullDescription = 'System ready. ' + message.description;
-                $('#divCapabilitiesSystemAlert').html('');
-                break;
-
-            case SYSTEM_ALERT_SHUTDOWN: 
-                session_isSystemAlert.ready = false;
-                listenerSystemAlert.unsubscribe();
-                //Show modal popup for Fatal alerts.
-                messageTypeFullDescription = 'PLEASE TAKE <strong>MANUAL</strong> CONTROL OF THE VEHICLE.';
-                messageTypeFullDescription += '<br/><br/>System received a SHUTDOWN message. Please wait for system to shut down. <br/><br/>' + message.description;
-                listenerSystemAlert.unsubscribe();
-                //If this modal does not exist, create one 
-                if( $('#systemAlertModal').length < 1 ) 
-                { 
-                    $('#ModalsArea').append(createSystemAlertModal(
-                        '<span style="color:red"><i class="fas fa-exclamation-triangle"></i></span>&nbsp;&nbsp;SYSTEM ALERT', 
-                        messageTypeFullDescription,
-                        false,true
-                        ));              
-                }
-                $('#systemAlertModal').modal({backdrop: 'static', keyboard: false}); 
-                playSound('audioAlert1', false);
-                break;
-
-            default:
-                session_isSystemAlert.ready = false;
-                messageTypeFullDescription = 'System alert type is unknown. Assuming system it not yet ready.  ' + message.description;
-                break;
-        }
-        let currentTime = new Date().toLocaleTimeString("en-US", {timeZone: "America/New_York"});
-        let eachElement = currentTime+'-'+messageTypeFullDescription + "&#13;&#10;";
-        let eachElementLeight = eachElement.length;
-        $('#logs-panel-text-system-alert').prepend( eachElement );        
-        let currnettext = $('#logs-panel-text-system-alert').html();
-        if ( (currnettext.length / eachElementLeight) > MAX_LOG_LINES) 
-        {
-            $('#logs-panel-text-system-alert').html( currnettext.substring(0, (currnettext.length - eachElementLeight)) );
-        }
-    });
+    listenerSystemAlert.subscribe(systemAlertCallback);
 }

--- a/website/scripts/ros/ros_system_alert.js
+++ b/website/scripts/ros/ros_system_alert.js
@@ -10,12 +10,23 @@
 function checkSystemAlerts() {
 
     // Subscribing to a Topic
-    listenerSystemAlert = new ROSLIB.Topic({
-        ros: g_ros,
-        name: T_SYSTEM_ALERT,
-        messageType: M_SYSTEM_ALERT
-    });
-    let systemAlertQueue = [];
+    // Check if our global subscription variable is defined already
+    if (typeof listenerSystemAlert === 'undefined' || listenerSystemAlert === null) 
+    {
+        // Initialize a topic object
+        listenerSystemAlert = new ROSLIB.Topic({
+            ros: g_ros,
+            name: T_SYSTEM_ALERT,
+            messageType: M_SYSTEM_ALERT
+        });
+
+    } 
+    else // If it was defined, close the existing subscription so it can be reopened
+    {
+        listenerSystemAlert.unsubscribe()
+    }
+
+
     // Then we add a callback to be called every time a message is published on this topic.
     listenerSystemAlert.subscribe(function (message) 
     {


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
This PR resolves https://github.com/usdot-fhwa-stol/carma-platform/issues/1703 by ensuring that the global scoped topic object only gets created once during the startup interval loop used to check driver status. If the object already exists then the callback is removed such that a new subscription can be created. 

An alternative approach might be to only call subscriber() once, but it was unclear to me if that call needed to be done every time such that the statup interval loop would ensure valid connection. 

Solution was informed based on similar issues reported here https://github.com/RobotWebTools/roslibjs/issues/343 and https://github.com/RobotWebTools/roslibjs/issues/288
<!--- Describe your changes in detail -->

## Related Issue
Fixes https://github.com/usdot-fhwa-stol/carma-platform/issues/1703
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
UI does not get cluttered with duplicate alerts
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Successfully tested in silver lexus. 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.