### PR TITLE
Fix remote launch

### DIFF
--- a/docker/install.sh
+++ b/docker/install.sh
@@ -29,17 +29,17 @@ add-apt-repository \
         $(lsb_release -cs) \
         stable"
 
-# Ensure docker group id is 999. CARMA UI is dependent on having the group id be the same between the image and vehicle PC.
+# Ensure docker group id is 998. CARMA UI is dependent on having the group id be the same between the image and vehicle PC.
 if [[ -z $(grep  -i "docker" /etc/group) ]]; then
-    	echo "User docker does not exists in /etc/group, creating docker group id of 999"
-   	    addgroup --gid 999 docker
+    	echo "User docker does not exists in /etc/group, creating docker group id of 998"
+   	    addgroup --gid 998 docker
 else
 	echo "User docker already exists in /etc/group."
 
-	if [[ $(grep  -i "docker" /etc/group) == *"docker:x:999"* ]]; then
+	if [[ $(grep  -i "docker" /etc/group) == *"docker:x:998"* ]]; then
 	    echo "Docker group id is correct"
 	else
-	    echo "ERROR: CARMA requires the docker group id 999 in the host PC. Please update the Host PC to correct this before trying again."
+	    echo "ERROR: CARMA requires the docker group id 998 in the host PC. Please update the Host PC to correct this before trying again."
 	    exit
 	fi
 fi
@@ -47,7 +47,7 @@ fi
 # Install docker and docker-compose
 apt-get update
 apt-get -y install docker-ce 
-curl -L "https://github.com/docker/compose/releases/download/1.23.1/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+curl -L "https://github.com/docker/compose/releases/download/1.29.1/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
 chmod +x /usr/local/bin/docker-compose
 
 # Configure user permissions for docker


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
This PR fixes the remote launch behavior for carma-platform with two changes. First, the docker group id is updated to 998 instead of 999 to support the default single user assignment of ubuntu 20.04. Second, the docker-compose version is updated to support the "runtime:" tag which is present in our current compose files in carma-config. 

The remote logout behavior was also tested after this fix and shown to be working.

<!--- Describe your changes in detail -->

## Related Issue
Resolves https://github.com/usdot-fhwa-stol/carma-platform/issues/1701  and https://github.com/usdot-fhwa-stol/carma-platform/issues/1277
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
All expected UI functionality should work as expected on default deployment configurations
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Successfully tested in silver lexus and I confirmed the docker group id in two vehicles (black pacifica, and silver lexus)
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.