### PR TITLE
Traffic signal display on the UI should only account for current event_state

### DIFF
--- a/website/scripts/ros/ros_traffic_signal.js
+++ b/website/scripts/ros/ros_traffic_signal.js
@@ -59,7 +59,6 @@ function TrafficSignalInfoList(){
                                             //set timer to count down ONY for current changed phase
                                             let current_phase_max_sec = getCurPhaseMaxSecBySpatTiming(element.moy,event_ele.timing.min_end_time);
                                             remaining_time = current_phase_max_sec;
-                                            console.log("signal_state:"+signal_state + "remaining_time:"+ remaining_time);
 
                                             //Prevent repeating the same state                                    
                                             switch(signal_state)

--- a/website/scripts/ros/ros_traffic_signal.js
+++ b/website/scripts/ros/ros_traffic_signal.js
@@ -59,6 +59,7 @@ function TrafficSignalInfoList(){
                                             //set timer to count down ONY for current changed phase
                                             let current_phase_max_sec = getCurPhaseMaxSecBySpatTiming(element.moy,event_ele.timing.min_end_time);
                                             remaining_time = current_phase_max_sec;
+                                            console.log("signal_state:"+signal_state + "remaining_time:"+ remaining_time);
 
                                             //Prevent repeating the same state                                    
                                             switch(signal_state)
@@ -87,6 +88,7 @@ function TrafficSignalInfoList(){
                                                     console.error("Traffic signal state is invalid");
                                                     break;
                                             } 
+                                            return;
                                     });
                             }
                             

--- a/website/scripts/ros/ros_traffic_signal.js
+++ b/website/scripts/ros/ros_traffic_signal.js
@@ -52,7 +52,7 @@ function TrafficSignalInfoList(){
                             if(inner_ele.signal_group != unknown_signal_group && inner_ele.signal_group == intersection_signal_group_ids[1])
                             {
                                     latest_start_time = Date.now();
-                                    inner_ele.state_time_speed.movement_event_list.forEach(event_ele=>{
+                                    inner_ele.state_time_speed.movement_event_list.every(event_ele=>{
                                         let signal_state = event_ele.event_state.movement_phase_state;
 
                                             signalStateTracking = signal_state;
@@ -88,7 +88,7 @@ function TrafficSignalInfoList(){
                                                     console.error("Traffic signal state is invalid");
                                                     break;
                                             } 
-                                            return;
+                                            return false;
                                     });
                             }
                             


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
The traffic signal display loops through the list of event state for each signal group. If there are multiple event state for a signal group, it should only pick the first event state and ignore the future event state.

<!--- Describe your changes in detail -->

## Related Issue
https://github.com/usdot-fhwa-stol/carma-platform/issues/1970
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
UC3 testing
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Integration test with vehicle
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](Contributing.md) 
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.