### PR TITLE
Modify to sim time

### DIFF
--- a/website/scripts/app/global_variables.js
+++ b/website/scripts/app/global_variables.js
@@ -32,7 +32,7 @@ const T_DRIVER_DISCOVERY = '/hardware_interface/driver_discovery';
 const T_ROUTE_STATE = '/guidance/route_state';
 const T_ROUTE_EVENT = '/guidance/route_event';
 const T_ROUTE = '/guidance/route';
-const T_ABBR_ROUTE_STATE = '/guidance/route_state'; 
+const T_ABBR_ROUTE_STATE = '/guidance/route_state';
 const T_ROBOTIC_STATUS = 'controller/robotic_status';
 const T_INCOMING_BSM = '/message/incoming_bsm';
 const T_NAV_SAT_FIX = '/hardware_interface/gnss/fix_raw';//'nav_sat_fix';
@@ -63,6 +63,7 @@ const T_LANE_CHANGE_STATUS = "/guidance/cooperative_lane_change_status";
 const T_TCR_BOUNDING_POINTS = "/environment/tcr_bounding_points";
 const T_GNSS_FIX_FUSED="/hardware_interface/gnss_fix_fused";
 const T_J2735_SPAT="/message/incoming_j2735_spat";
+const T_SIM_CLOCK="/sim_clock";
 const T_INTERSECTION_SIGNAL_GROUP_IDS="/environment/intersection_signal_group_ids";
 const T_UI_INSTRUCTION ="/ui/ui_instructions";
 const T_ERV_STATUS="/guidance/approaching_erv_status";
@@ -119,6 +120,7 @@ const M_LANE_CHANGE_STATUS = "carma_planning_msgs/msg/LaneChangeStatus";
 const M_TCR_POLYGON = "carma_v2x_msgs/msg/TrafficControlRequestPolygon"
 const M_GPS_COMMON_GPSFIX="gps_msgs/msg/GPSFix";
 const M_J2735_SPAT="j2735_v2x_msgs/msg/SPAT";
+const M_ROS_CLOCK="rosgraph_msgs/msg/Clock";
 const M_MULTI_ARRAY="std_msgs/msg/Int32MultiArray";
 const M_ERV_UIInstruction="carma_msgs/msg/UIInstructions";
 
@@ -225,12 +227,12 @@ var isModalPopupShowing = false;
 var sound_counter=0;
 var sound_counter_max=0;
 
-//map 
+//map
 var map;
 var bounds;
 var markers=[];
 var hostmarker;
-var map_frame = null;  //map iframe 
+var map_frame = null;  //map iframe
 var map_content_window = null; //map iframe content window
 var map_doc = null;
 var tcr_polygon = null;
@@ -255,5 +257,3 @@ var g_play_audio_error = false; //No Error
 var session_isGuidance = null;
 var session_selectedRoute = null;
 var session_isSystemAlert = null;
-
-

--- a/website/scripts/ros/ros_traffic_signal.js
+++ b/website/scripts/ros/ros_traffic_signal.js
@@ -87,12 +87,6 @@ function TrafficSignalInfoList(){
                                         sim_clock_time
                                     );
 
-                                    // Ensure we have a valid number
-                                    if (isNaN(current_phase_max_sec) || current_phase_max_sec === null) {
-                                        console.error("[ERROR] Invalid countdown value (NaN) - using default");
-                                        current_phase_max_sec = 30; // Default fallback value
-                                    }
-
                                     //Prevent repeating the same state
                                     switch(signal_state) {
                                         case TRAFFIC_SIGNAL_PHASE_STATE.protected_movement_allowed:
@@ -168,26 +162,22 @@ function getCurPhaseMaxSecBySpatTiming(moy, min_end_time, use_sim_clock = false,
     // Check for invalid inputs that could cause NaN
     if (moy === undefined || moy === null || isNaN(moy)) {
         console.error("[ERROR] Invalid moy value:", moy);
-        return 30; // Default fallback
+        return NaN; // Return NaN to indicate invalid input
     }
 
     if (min_end_time === undefined || min_end_time === null || isNaN(min_end_time)) {
         console.error("[ERROR] Invalid min_end_time value:", min_end_time);
-        return 30; // Default fallback
+        return NaN; // Return NaN to indicate invalid input
     }
 
     let current_phase_max_sec = 0;
 
-    //get current year
-    let current_date;
-    let now = Date.now();
+    //get current year (real time as a default)
+    let current_date = new Date();
 
     if (use_sim_clock && sim_clock_time !== null && !isNaN(sim_clock_time)) {
         // Use simulation time
         current_date = new Date(sim_clock_time);
-    } else {
-        // Use real time
-        current_date = new Date(now);
     }
 
     let current_year = current_date.getUTCFullYear();
@@ -231,7 +221,7 @@ function getCurPhaseMaxSecBySpatTiming(moy, min_end_time, use_sim_clock = false,
 
     if (isNaN(time_diff)) {
         console.error("[ERROR] Time difference calculation resulted in NaN");
-        return 30; // Default fallback
+        return NaN; // Default fallback
     }
 
     current_phase_max_sec = time_diff / 1000;

--- a/website/scripts/ros/ros_traffic_signal.js
+++ b/website/scripts/ros/ros_traffic_signal.js
@@ -30,85 +30,150 @@ function TrafficSignalInfoList(){
         messageType: M_J2735_SPAT
     });
 
+    listener_sim_clock = new ROSLIB.Topic({
+        ros: g_ros,
+        name: T_SIM_CLOCK,
+        messageType: M_ROS_CLOCK
+    });
+
+    // Variables to track simulation vs real clock
+    let useSimClock = false;
+    let simClockTime = null;
+    let lastRealTime = Date.now();
+    let lastSimTime = null;
+
+    // Subscribe to simulation clock
+    listener_sim_clock.subscribe(function(message) {
+        if (!IsROSBridgeConnected()) {
+            return;
+        }
+
+        // If we receive sim clock data, use it
+        if (message && message.clock) {
+            // nsec is somehow not undefined, but we don't need it
+            const nsec = message.clock.nsec !== undefined ? Number(message.clock.nsec) : 0;
+            useSimClock = true;
+            // Convert ROS time (seconds and nanoseconds) to milliseconds
+            let newSimTime = message.clock.sec * 1000 + Math.floor(nsec) / 1000000;
+            simClockTime = newSimTime;
+            lastSimTime = newSimTime;
+            lastRealTime = Date.now();
+        } else {
+            console.log("[WARN] Sim clock message received but invalid format");
+        }
+    });
+
     let signalStateTracking = 0; //0 -> unavailable
-    let latest_start_time =  Date.now();
+    let latest_start_time = Date.now();
+    let sim_start_time = null;
     let remaining_time = 0;
-    listener.subscribe(function (message) 
-    {
+
+    listener.subscribe(function (message) {
         //Check ROSBridge connection before subscribe a topic
-        if (!IsROSBridgeConnected())
-        {
+        if (!IsROSBridgeConnected()) {
             return;
         };
 
-         try{
+        try {
             if(message!=undefined && message.intersections != undefined && Array.isArray(message.intersections.intersection_state_list)){
                 message.intersections.intersection_state_list.forEach(element=>{
                     //Checking intersection id
-                    if(element.id.id != unknown_intersection_id && element.id.id == intersection_signal_group_ids[0])
-                    {
+                    if(element.id.id != unknown_intersection_id && element.id.id == intersection_signal_group_ids[0]) {
                         element.states.movement_list.forEach(inner_ele=>{
                             //Checking signal group id
-                            if(inner_ele.signal_group != unknown_signal_group && inner_ele.signal_group == intersection_signal_group_ids[1])
-                            {
-                                    latest_start_time = Date.now();
-                                    inner_ele.state_time_speed.movement_event_list.every(event_ele=>{
-                                        let signal_state = event_ele.event_state.movement_phase_state;
+                            if(inner_ele.signal_group != unknown_signal_group && inner_ele.signal_group == intersection_signal_group_ids[1]) {
+                                // Update start time based on clock mode
+                                latest_start_time = Date.now();
+                                if (useSimClock && simClockTime !== null) {
+                                    sim_start_time = simClockTime;
+                                }
 
-                                            signalStateTracking = signal_state;
-                                            //set timer to count down ONY for current changed phase
-                                            let current_phase_max_sec = getCurPhaseMaxSecBySpatTiming(element.moy,event_ele.timing.min_end_time);
-                                            remaining_time = current_phase_max_sec;
+                                inner_ele.state_time_speed.movement_event_list.every(event_ele=>{
+                                    let signal_state = event_ele.event_state.movement_phase_state;
 
-                                            //Prevent repeating the same state                                    
-                                            switch(signal_state)
-                                            {
-                                                case TRAFFIC_SIGNAL_PHASE_STATE.protected_movement_allowed:
-                                                    $('.traffic-signal-col').html(updateTrafficSignal('green',remaining_time));
-                                                    break;
-                                                case TRAFFIC_SIGNAL_PHASE_STATE.stop_and_remain:
-                                                    $('.traffic-signal-col').html(updateTrafficSignal('red',remaining_time));
-                                                    break;
-                                                case TRAFFIC_SIGNAL_PHASE_STATE.protected_clearance:
-                                                    $('.traffic-signal-col').html(updateTrafficSignal('yellow',remaining_time));
-                                                    break;
-                                                case TRAFFIC_SIGNAL_PHASE_STATE.permissive_movement_allowed:
-                                                    $('.traffic-signal-col').html(updateTrafficSignal('flash_green',remaining_time));
-                                                    break;
-                                                case TRAFFIC_SIGNAL_PHASE_STATE.permissive_clearance:
-                                                case TRAFFIC_SIGNAL_PHASE_STATE.caution_conflicting_traffic:
-                                                    $('.traffic-signal-col').html(updateTrafficSignal('flash_yellow',remaining_time));
-                                                    break;
-                                                case TRAFFIC_SIGNAL_PHASE_STATE.stop_then_proceed:
-                                                    $('.traffic-signal-col').html(updateTrafficSignal('flash_red',remaining_time));
-                                                    break;
-                                                default:
-                                                    $('.traffic-signal-col').html(updateTrafficSignal('',''));
-                                                    console.error("Traffic signal state is invalid");
-                                                    break;
-                                            } 
-                                            return false;
-                                    });
+                                    signalStateTracking = signal_state;
+                                    //set timer to count down ONLY for current changed phase
+
+                                    let current_phase_max_sec = getCurPhaseMaxSecBySpatTiming(
+                                        element.moy,
+                                        event_ele.timing.min_end_time,
+                                        useSimClock,
+                                        simClockTime
+                                    );
+
+                                    // Ensure we have a valid number
+                                    if (isNaN(current_phase_max_sec) || current_phase_max_sec === null) {
+                                        console.error("[ERROR] Invalid countdown value (NaN) - using default");
+                                        current_phase_max_sec = 30; // Default fallback value
+                                    }
+
+                                    remaining_time = current_phase_max_sec;
+
+                                    //Prevent repeating the same state
+                                    switch(signal_state) {
+                                        case TRAFFIC_SIGNAL_PHASE_STATE.protected_movement_allowed:
+                                            $('.traffic-signal-col').html(updateTrafficSignal('green',remaining_time));
+                                            break;
+                                        case TRAFFIC_SIGNAL_PHASE_STATE.stop_and_remain:
+                                            $('.traffic-signal-col').html(updateTrafficSignal('red',remaining_time));
+                                            break;
+                                        case TRAFFIC_SIGNAL_PHASE_STATE.protected_clearance:
+                                            $('.traffic-signal-col').html(updateTrafficSignal('yellow',remaining_time));
+                                            break;
+                                        case TRAFFIC_SIGNAL_PHASE_STATE.permissive_movement_allowed:
+                                            $('.traffic-signal-col').html(updateTrafficSignal('flash_green',remaining_time));
+                                            break;
+                                        case TRAFFIC_SIGNAL_PHASE_STATE.permissive_clearance:
+                                        case TRAFFIC_SIGNAL_PHASE_STATE.caution_conflicting_traffic:
+                                            $('.traffic-signal-col').html(updateTrafficSignal('flash_yellow',remaining_time));
+                                            break;
+                                        case TRAFFIC_SIGNAL_PHASE_STATE.stop_then_proceed:
+                                            $('.traffic-signal-col').html(updateTrafficSignal('flash_red',remaining_time));
+                                            break;
+                                        default:
+                                            $('.traffic-signal-col').html(updateTrafficSignal('',''));
+                                            console.error("Traffic signal state is invalid");
+                                            break;
+                                    }
+                                    return false;
+                                });
                             }
-                            
                         });
-                    }                    
+                    }
                 });
             }
-         }catch(error){
+        } catch(error) {
             console.error(error);
-         }  
+        }
 
-         //set back to black after 1 second.
-        setInterval(function()
-        {
-            let elapsed_time = Date.now() - latest_start_time;
-            if(elapsed_time >= 1000)
-            {
+        // Create only one interval to avoid memory leaks
+        if (!window.signalIntervalCreated) {
+            window.signalIntervalCreated = true;
+            setInterval(function() {
+                let elapsed_time;
+
+                // Use sim clock for timing if available
+                if (useSimClock && simClockTime !== null && sim_start_time !== null) {
+                    // Calculate elapsed time in simulation
+                    let currentRealTime = Date.now();
+                    let realTimeDiff = currentRealTime - lastRealTime;
+
+                    // Estimate current sim time based on real time elapsed and last known sim time
+                    // This handles the case where sim_clock messages come at lower frequency than needed
+                    let estimatedSimTime = lastSimTime + realTimeDiff;
+                    elapsed_time = estimatedSimTime - sim_start_time;
+
+                } else {
+                    // Fall back to real clock
+                    elapsed_time = Date.now() - latest_start_time;
+                }
+
+                if (elapsed_time >= 1000) {
                     $('.traffic-signal-col').html(updateTrafficSignal('',''));
                     signalState = null;
-            }
-         }, 1000);
+                }
+            }, 1000);
+        }
     });
 }
 
@@ -116,33 +181,88 @@ function TrafficSignalInfoList(){
  * @brief Given the timing from the icoming spat message, and return the count down for traffic signal phase change
  * @param Input moy (unit of min): Min of current UTC year.
  *              min_end_time (unit of 1/10 sec): Timing data in UTC time stamps for event. Include min end times of phase confidentce and estimated next occurrence
+ *              useSimClock: Boolean indicating whether to use simulation clock
+ *              simClockTime: Current simulation time in milliseconds (if available)
  * @returns current_phase_max_sec: The traffic signal will change phase in number of seconds.
  */
-function getCurPhaseMaxSecBySpatTiming(moy, min_end_time )
-{
-    let current_phase_max_sec = 0; 
+function getCurPhaseMaxSecBySpatTiming(moy, min_end_time, useSimClock = false, simClockTime = null) {
 
-    //get current year 
-    let current_date = new Date(Date.now());
+    // Check for invalid inputs that could cause NaN
+    if (moy === undefined || moy === null || isNaN(moy)) {
+        console.error("[ERROR] Invalid moy value:", moy);
+        return 30; // Default fallback
+    }
+
+    if (min_end_time === undefined || min_end_time === null || isNaN(min_end_time)) {
+        console.error("[ERROR] Invalid min_end_time value:", min_end_time);
+        return 30; // Default fallback
+    }
+
+    let current_phase_max_sec = 0;
+
+    //get current year
+    let current_date;
+    let now = Date.now();
+
+    if (useSimClock && simClockTime !== null && !isNaN(simClockTime)) {
+        // Use simulation time
+        current_date = new Date(simClockTime);
+    } else {
+        // Use real time
+        current_date = new Date(now);
+    }
+
     let current_year = current_date.getUTCFullYear();
-    let current_date_utc = new Date(Date.UTC(current_date.getUTCFullYear(), current_date.getUTCMonth(), current_date.getUTCDate(), current_date.getUTCHours(),current_date.getUTCMinutes(), current_date.getUTCSeconds(),current_date.getUTCMilliseconds()));
+
+    let current_date_utc = new Date(Date.UTC(
+        current_date.getUTCFullYear(),
+        current_date.getUTCMonth(),
+        current_date.getUTCDate(),
+        current_date.getUTCHours(),
+        current_date.getUTCMinutes(),
+        current_date.getUTCSeconds(),
+        current_date.getUTCMilliseconds()
+    ));
+
     //get current months, days, hours of the year based on moy (in mins)
     //An integer between 0 (January) and 11 (December) representing the month.
-    //An integer between 1 and 31 representing the day of the month. 
+    //An integer between 1 and 31 representing the day of the month.
     //An integer between 0 and 23 representing the hours.
     //An integer between 0 and 59 representing the minutes.
-    //An integer between 0 and 59 representing the seconds. 
-    let current_year_start = new Date(Date.UTC(current_year,00,01,00,00,00,000));
-    let current_year_add_moy = new Date(current_year_start.getTime() + moy*60*1000); 
+    //An integer between 0 and 59 representing the seconds.
+    let current_year_start = new Date(Date.UTC(current_year, 0, 1, 0, 0, 0, 0));
 
-    let current_year_month_day_hour = new Date(Date.UTC(current_year_add_moy.getUTCFullYear(), current_year_add_moy.getUTCMonth(),current_year_add_moy.getUTCDate(),current_year_add_moy.getUTCHours(),00,00,000));
-    
+    // Convert moy to a number to ensure math operations work correctly
+    let moy_number = Number(moy);
+    let current_year_add_moy = new Date(current_year_start.getTime() + moy_number * 60 * 1000);
+    let current_year_month_day_hour = new Date(Date.UTC(
+        current_year_add_moy.getUTCFullYear(),
+        current_year_add_moy.getUTCMonth(),
+        current_year_add_moy.getUTCDate(),
+        current_year_add_moy.getUTCHours(),
+        0, 0, 0
+    ));
+
+    // Convert min_end_time to a number to ensure math operations work correctly
+    let min_end_time_number = Number(min_end_time);
     //get current time in terms of seconds, minutes, hours, day, and year
-    let current_year_add_moy_add_min_end_time = new Date(current_year_month_day_hour.getTime() + min_end_time * 100); 
-    
-    current_phase_max_sec = (current_year_add_moy_add_min_end_time.getTime() - current_date_utc.getTime())/1000;
-    if(current_phase_max_sec < 0){
-        console.error("Signal timing is expired.");
+    let current_year_add_moy_add_min_end_time = new Date(current_year_month_day_hour.getTime() + min_end_time_number * 100);
+
+    // Calculate difference and ensure we get a valid number
+    let time_diff = current_year_add_moy_add_min_end_time.getTime() - current_date_utc.getTime();
+
+    if (isNaN(time_diff)) {
+        console.error("[ERROR] Time difference calculation resulted in NaN");
+        return 30; // Default fallback
     }
-    return current_phase_max_sec.toFixed(0);
+
+    current_phase_max_sec = time_diff / 1000;
+
+    if (current_phase_max_sec < 0) {
+        console.error("[ERROR] Signal timing is expired:", current_phase_max_sec);
+        return 0; // Return 0 for expired timing
+    }
+
+    let result = Math.max(0, Math.floor(current_phase_max_sec));
+    return result;
 }

--- a/website/utils/traffic_signal/traffic_signal.js
+++ b/website/utils/traffic_signal/traffic_signal.js
@@ -12,10 +12,10 @@ function updateTrafficSignal(signalType, signalCountDown)
     let  signalContainerDiv = document.getElementById('signal-container-id')
     if(signalContainerDiv == null || signalContainerDiv == "undefined"){
         signalContainerDiv = document.createElement('div');
-        signalContainerDiv.classList.add('signal-container'); 
+        signalContainerDiv.classList.add('signal-container');
         signalContainerDiv.id='signal-container-id';
     }
-    
+
     let signalCircleRed = document.getElementById('signal-circle-red');
     if(signalCircleRed == null || signalCircleRed == "undefined")
     {
@@ -23,11 +23,11 @@ function updateTrafficSignal(signalType, signalCountDown)
         signalCircleRed.classList.add('signal-circle');
         signalCircleRed.id = 'signal-circle-red';
     }
-    
+
     let signalCircleYellow = document.getElementById('signal-circle-yellow');
     if(signalCircleYellow == null || signalCircleYellow == "undefined")
     {
-        signalCircleYellow = document.createElement('div');        
+        signalCircleYellow = document.createElement('div');
         signalCircleYellow.classList.add('signal-circle');
         signalCircleYellow.id = 'signal-circle-yellow';
     }
@@ -37,7 +37,7 @@ function updateTrafficSignal(signalType, signalCountDown)
         signalCircleGreen = document.createElement('div');
         signalCircleGreen.classList.add('signal-circle');
         signalCircleGreen.id = 'signal-circle-green';
-    }   
+    }
     //reset signal state
     signalCircleRed.classList.remove(SIGNAL_RED,SIGNAL_FLASHING_RED);
     signalCircleGreen.classList.remove(SIGNAL_GREEN,SIGNAL_FLASHING_GREEN);
@@ -48,33 +48,33 @@ function updateTrafficSignal(signalType, signalCountDown)
 
     switch(signalType)
     {
-       
+
         case SIGNAL_RED:
             signalCircleRed.classList.add(signalType);
             signalCircleRed.innerHTML = signalCountDown;
             break;
-        case SIGNAL_GREEN: 
+        case SIGNAL_GREEN:
             signalCircleGreen.classList.add(signalType);
             signalCircleGreen.innerHTML = signalCountDown;
             break;
-        case SIGNAL_YELLOW: 
+        case SIGNAL_YELLOW:
             signalCircleYellow.classList.add(signalType);
             signalCircleYellow.innerHTML = signalCountDown;
             break;
-        case SIGNAL_FLASHING_YELLOW: 
+        case SIGNAL_FLASHING_YELLOW:
             signalCircleYellow.classList.add(signalType);
             signalCircleYellow.innerHTML = signalCountDown;
             break;
-        case SIGNAL_FLASHING_GREEN: 
+        case SIGNAL_FLASHING_GREEN:
             signalCircleGreen.classList.add(signalType);
             signalCircleGreen.innerHTML = signalCountDown;
             break;
-        case SIGNAL_FLASHING_RED: 
+        case SIGNAL_FLASHING_RED:
             signalCircleRed.classList.add(signalType);
             signalCircleRed.innerHTML = signalCountDown;
             break;
         default:
-            
+
             break;
     }
     signalContainerDiv.appendChild(signalCircleRed);


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description
Modify UI to showcase Simulation Countdown time SPAT.
Currently, the UI shows arbitrary high countdown because it expects wall-time, but in simulation it should use /sim_clock

<!--- Describe your changes in detail -->

## Related GitHub Issue
NA
<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key
CDAD-79
Felt appropriate to fix this during preparation for UC2 use case.

<!-- e.g. CAR-123 -->

## Motivation and Context
Demo prep for UC2
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Sim PC1. Performed UC2 in simulation, video:
https://youtu.be/uyQeT1Kdvtk
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
