### PR TITLE
Remove 'There were no segments found the active route.' text from Web UI

### DIFF
--- a/website/scripts/ros/ros_route.js
+++ b/website/scripts/ros/ros_route.js
@@ -325,7 +325,6 @@ function showActiveRoute()
         //If nothing on the list, set all selected checkboxes back to blue (or active).
         if (message.segments == null || message.segments.length == 0) 
         {
-            $('#divCapabilitiesRoute').append(' There were no segments found the active route. ');
             $('#divCapabilitiesContent').css('display','inline-block');
             return;
         }


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->
Prior to this PR, the CARMA Web UI displayed "There were no segments found the active route." whenever a route was successfully generated. This text was confusing and seemed to imply that routing was unsuccessful. This PR removes this text.

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Related Jira Key

<!-- e.g. CAR-123 -->
CDAD-171

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This text was confusing and seemed to imply that routing was unsuccessful.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
TODO

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
